### PR TITLE
fix: load gzipped Snowflake stage manifests

### DIFF
--- a/dbt_loom/clients/snowflake_stage.py
+++ b/dbt_loom/clients/snowflake_stage.py
@@ -11,6 +11,16 @@ from dbt_loom.logging import fire_event
 from pydantic import BaseModel
 
 
+def _load_downloaded_manifest(download_path: Path) -> Dict:
+    """Read a plain or gzip-compressed manifest downloaded from a stage."""
+    content = download_path.read_bytes()
+
+    if is_gzipped(content):
+        content = gzip.decompress(content)
+
+    return json.loads(content)
+
+
 class SnowflakeReferenceConfig(BaseModel):
     """Configuration for an reference stored in Snowflake Stage"""
 
@@ -72,11 +82,4 @@ class SnowflakeClient:
 
         download_path = Path(tmp_dir) / file_name
 
-        with download_path.open("r") as f:
-            content = f.read()
-
-        if is_gzipped(content.encode()):
-            with gzip.GzipFile(content) as gzip_file:
-                content = gzip_file.read().decode("utf-8")
-
-        return json.loads(content)
+        return _load_downloaded_manifest(download_path)

--- a/tests/test_snowflake_stage.py
+++ b/tests/test_snowflake_stage.py
@@ -1,0 +1,20 @@
+import gzip
+import json
+
+from dbt_loom.clients.snowflake_stage import _load_downloaded_manifest
+
+
+def test_load_downloaded_manifest_reads_plain_json(tmp_path):
+    manifest = {"metadata": {"dbt_version": "1.12.2"}}
+    download_path = tmp_path / "manifest.json"
+    download_path.write_text(json.dumps(manifest))
+
+    assert _load_downloaded_manifest(download_path) == manifest
+
+
+def test_load_downloaded_manifest_reads_gzip_json(tmp_path):
+    manifest = {"metadata": {"dbt_version": "1.12.2"}}
+    download_path = tmp_path / "manifest.json.gz"
+    download_path.write_bytes(gzip.compress(json.dumps(manifest).encode("utf-8")))
+
+    assert _load_downloaded_manifest(download_path) == manifest


### PR DESCRIPTION
Fixes #189 by reading Snowflake stage downloads as bytes before gzip detection.